### PR TITLE
FIX Dockerfile3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM ruby:3.1.2
 
-# Linux環境でも source install にする
-ENV BUNDLE_FORCE_RUBY_PLATFORM=true
-
 # 必要なパッケージをインストール
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
-
-# Tailwind CSS の Linux バイナリをインストール
-RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
-    && mv tailwindcss-linux-x64 tailwindcss \
-    && chmod +x tailwindcss \
-    && mv tailwindcss /usr/local/bin/
 
 # 作業ディレクトリの設定
 WORKDIR /myapp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     connection_pool (2.5.3)
     crass (1.0.6)
     date (3.4.1)
-    debug (1.10.0)
+    debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.3)
@@ -130,13 +130,12 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -146,14 +145,11 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.18.8-aarch64-linux)
+    nokogiri (1.18.8-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.8-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.8-arm-linux)
+    nokogiri (1.18.8-arm-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.8-arm-linux-musl)
       racc (~> 1.4)
@@ -161,7 +157,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux)
+    nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
@@ -214,7 +210,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.3.0)
-    rdoc (6.14.0)
+    rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -241,11 +237,11 @@ GEM
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
     tailwindcss-ruby (4.1.10)
-    tailwindcss-ruby (4.1.10-aarch64-linux)
+    tailwindcss-ruby (4.1.10-aarch64-linux-gnu)
     tailwindcss-ruby (4.1.10-aarch64-linux-musl)
     tailwindcss-ruby (4.1.10-arm64-darwin)
     tailwindcss-ruby (4.1.10-x86_64-darwin)
-    tailwindcss-ruby (4.1.10-x86_64-linux)
+    tailwindcss-ruby (4.1.10-x86_64-linux-gnu)
     tailwindcss-ruby (4.1.10-x86_64-linux-musl)
     thor (1.3.2)
     timeout (0.4.3)
@@ -273,14 +269,14 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
-  aarch64-linux
+  aarch64-linux-gnu
   aarch64-linux-musl
-  arm-linux
+  arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  ruby
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES


### PR DESCRIPTION
Dockerfile

ENV BUNDLE_FORCE_RUBY_PLATFORM=true　を削除

RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 \
    && mv tailwindcss-linux-x64 tailwindcss \
    && chmod +x tailwindcss \
    && mv tailwindcss /usr/local/bin/　を削除

bundle installやり直し