### PR TITLE
フォント初期データの登録

### DIFF
--- a/app/models/font.rb
+++ b/app/models/font.rb
@@ -1,0 +1,2 @@
+class Font < ApplicationRecord
+end

--- a/db/migrate/20250624121734_create_fonts.rb
+++ b/db/migrate/20250624121734_create_fonts.rb
@@ -1,0 +1,13 @@
+class CreateFonts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :fonts do |t|
+      t.string :name, null: false
+      t.string :style, null: false
+      t.string :genre, null: false
+      t.string :font_url
+      t.string :download_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_24_121734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "fonts", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "style", null: false
+    t.string "genre", null: false
+    t.string "font_url"
+    t.string "download_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,98 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+Font.create!([
+  {
+    name: "Noto Serif JP",
+    style: "明朝体",
+    genre: "上品",
+    font_url: "https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&display=swap",
+    download_url: "https://fonts.google.com/noto/specimen/Noto+Serif+JP"
+  },
+
+  {
+    name: "さわらび明朝",
+    style: "明朝体",
+    genre: "上品",
+    font_url: "https://fonts.googleapis.com/css2?family=Sawarabi+Mincho&display=swap",
+    download_url: "https://fonts.google.com/specimen/Sawarabi+Mincho"
+  },
+
+  {
+    name: "Noto Sans JP",
+    style: "ゴシック体",
+    genre: "ビジネス",
+    font_url: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap",
+    download_url: "https://fonts.google.com/specimen/Noto+Sans+JP"
+  },
+
+  {
+    name: "M PLUS 1p",
+    style: "ゴシック体",
+    genre: "ビジネス",
+    font_url: "https://fonts.googleapis.com/css2?family=M+PLUS+1p&display=swap",
+    download_url: "https://fonts.google.com/specimen/M+PLUS+1p"
+  },
+
+  {
+    name: "Dela Gothic One",
+    style: "ゴシック体",
+    genre: "インパクト",
+    font_url: "https://fonts.googleapis.com/css2?family=Dela+Gothic+One&display=swap",
+    download_url: "https://fonts.google.com/specimen/Dela+Gothic+One"
+  },
+
+  {
+    name: "M PLUS Rounded 1c",
+    style: "丸ゴシック体",
+    genre: "かわいい",
+    font_url: "https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&display=swap",
+    download_url: "https://fonts.google.com/specimen/M+PLUS+Rounded+1c"
+  },
+
+  {
+    name: "Zen Maru Gothic",
+    style: "丸ゴシック体",
+    genre: "かわいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic&display=swap",
+    download_url: "https://fonts.google.com/specimen/Zen+Maru+Gothic"
+  },
+
+  {
+    name: "Yuji Boku",
+    style: "筆書体",
+    genre: "かっこいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Yuji+Boku&display=swap",
+    download_url: "https://fonts.google.com/specimen/Yuji+Boku"
+  },
+
+  {
+    name: "Yuji Mai",
+    style: "筆書体",
+    genre: "かっこいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Yuji+Mai&display=swap",
+    download_url: "https://fonts.google.com/specimen/Yuji+Mai"
+  },
+
+  {
+    name: "Yuji Syuku",
+    style: "筆書体",
+    genre: "かっこいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Yuji+Syuku&display=swap",
+    download_url: "https://fonts.google.com/specimen/Yuji+Syuku"
+  },
+
+  {
+    name: "Kaisei Decol",
+    style: "デザインフォント",
+    genre: "かわいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Kaisei+Decol&display=swap",
+    download_url: "https://fonts.google.com/specimen/Kaisei+Decol"
+  },
+
+  {
+    name: "Mochiy Pop One",
+    style: "デザインフォント",
+    genre: "かわいい",
+    font_url: "https://fonts.googleapis.com/css2?family=Mochiy+Pop+One&display=swap",
+    download_url: "https://fonts.google.com/specimen/Mochiy+Pop+One"
+  }
+
+])

--- a/test/fixtures/fonts.yml
+++ b/test/fixtures/fonts.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  style: MyString
+  genre: MyString
+  font_url: MyString
+  download_url: MyString
+
+two:
+  name: MyString
+  style: MyString
+  genre: MyString
+  font_url: MyString
+  download_url: MyString

--- a/test/models/font_test.rb
+++ b/test/models/font_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FontTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## ✅ Fontモデル作成と初期データ登録の作業まとめ

### ■ 目的

日本語Webフォント情報をアプリ上で扱えるようにするための `Font` モデルを作成し、初期データをシードファイルに登録。アプリケーションのトップページでのフォント表示・プレビュー機能の土台を整える。

---

### ■ 作業内容

#### 1. Fontモデルの作成

`name`, `style`, `genre`, `font_url`, `download_url` の5つのカラムを持つモデルを作成。

```bash
bin/rails g model Font name:string style:string genre:string font_url:string download_url:string
```

#### 2. マイグレーション修正

マイグレーションファイルに `null: false` 制約を追加（**name / style / genre** は必須項目とするため）：

```ruby
t.string :name, null: false
t.string :style, null: false
t.string :genre, null: false
t.string :font_url
t.string :download_url
```

その後マイグレーションを実行：

```bash
bin/rails db:migrate
```

---

#### 3. 初期データ登録（Seed）

`db/seeds.rb` に、日本語Webフォント数種（例：Noto Sans JP, M PLUS, Zen Maru Gothic など）を登録。

```ruby
Font.create!(
  name: "Noto Sans JP",
  style: "ゴシック体",
  genre: "ビジネス",
  font_url: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap",
  download_url: "https://fonts.google.com/specimen/Noto+Sans+JP"
)
# 他にも数件登録
```

登録済みのフォントは「Mochiy Pop One」「Dela Gothic One」など複数種類。

#### 4. シードデータの反映

```bash
bin/rails db:seed
```

これにより、開発環境で使用可能なフォントデータがDBに登録された。

---

### ■ このPRの役割

* `Font` モデルおよびテーブル作成
* 必須カラムにバリデーションを追加（null: false）
* フォント初期データをシードファイルで登録

この状態で、今後のトップページ実装（テキスト入力＋フィルター＋フォントプレビュー）のための土台が整った段階です。

