### PR TITLE
feat: フォントプレビュー機能のJavaScript実装

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 ////= link_tree ../builds
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,4 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "font_preview"
+
+console.log("Application JavaScript loaded with importmap!");

--- a/app/javascript/font_preview.js
+++ b/app/javascript/font_preview.js
@@ -1,0 +1,64 @@
+// フォントプレビュー機能
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('Font preview script loaded!');
+    
+    const textInput = document.getElementById('preview-text');
+    const fontSizeSlider = document.getElementById('font-size');
+    const fontSizeDisplay = document.getElementById('font-size-display');
+    const styleFilter = document.getElementById('style-filter');
+    const genreFilter = document.getElementById('genre-filter');
+    const previewTexts = document.querySelectorAll('.preview-text');
+    const fontCards = document.querySelectorAll('[data-style]');
+    
+    // 要素の存在確認
+    if (!textInput || !fontSizeSlider || !previewTexts.length) {
+      console.log('必要な要素が見つかりません');
+      return;
+    }
+    
+    // テキスト更新機能
+    function updatePreviewText() {
+      const inputValue = textInput.value || 'こんにちは';
+      previewTexts.forEach(function(element) {
+        element.textContent = inputValue;
+      });
+    }
+    
+    // 文字サイズ更新機能
+    function updateFontSize() {
+      const fontSize = fontSizeSlider.value + 'px';
+      fontSizeDisplay.textContent = fontSize;
+      previewTexts.forEach(function(element) {
+        element.style.fontSize = fontSize;
+      });
+    }
+    
+    // フィルター機能
+    function applyFilters() {
+      if (!styleFilter || !genreFilter || !fontCards.length) return;
+      
+      const selectedStyle = styleFilter.value;
+      const selectedGenre = genreFilter.value;
+      
+      fontCards.forEach(function(card) {
+        const cardStyle = card.dataset.style;
+        const cardGenre = card.dataset.genre;
+        
+        const showCard = (!selectedStyle || cardStyle === selectedStyle) && 
+                        (!selectedGenre || cardGenre === selectedGenre);
+        
+        card.style.display = showCard ? 'block' : 'none';
+      });
+    }
+    
+    // イベントリスナー設定
+    textInput.addEventListener('input', updatePreviewText);
+    fontSizeSlider.addEventListener('input', updateFontSize);
+    
+    if (styleFilter) styleFilter.addEventListener('change', applyFilters);
+    if (genreFilter) genreFilter.addEventListener('change', applyFilters);
+    
+    // 初期化
+    updatePreviewText();
+    updateFontSize();
+  });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,2 @@
+pin "application", preload: true
+pin "font_preview", to: "font_preview.js"


### PR DESCRIPTION
## 実装内容
- テキストボックスに入力したテキストがカード側に即時反映される機能を実装

## 変更ファイル
- `config/importmap.rb` - font_preview.jsの読み込み設定追加
- `app/javascript/application.js` - font_previewモジュールのimport追加
- `app/javascript/font_preview.js` - フォントプレビュー機能の実装

## 動作確認
- [x] テキストボックスへの入力
- [x] カード側への即時反映
- [x] 各種文字種での動作確認
- [x] ブラウザコンソールでのエラー確認