### PR TITLE
fix: Change render.yaml from docker to ruby environment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,10 @@
 services:
   - type: web
     name: fontmikke
-    env: docker
+    env: ruby
     plan: free
     region: singapore
     branch: main
-    dockerfilePath: ./Dockerfile
     envVars:
       - key: RAILS_MASTER_KEY
         sync: false


### PR DESCRIPTION
Renderデプロイ時に発生するBundlerエラーの解消を目的とした修正。

render.yamlの環境をdockerからrubyに変更。