### PR TITLE
fix: Configure render.yaml to use existing database

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,15 @@ services:
     plan: free
     region: singapore
     branch: main
+
+    buildCommand: |
+      gem install bundler -v 2.4.22
+      bundle install
+      bundle exec rake assets:precompile
+      bundle exec rake assets:clean
+      bin/rails db:migrate
+    startCommand: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+
     envVars:
       - key: RAILS_MASTER_KEY
         sync: false
@@ -15,6 +24,4 @@ services:
       - key: RAILS_SERVE_STATIC_FILES
         value: true
       - key: DATABASE_URL
-        fromDatabase:
-          name: fontmikke-db
-          property: connectionString
+        sync: false


### PR DESCRIPTION
render.yamlを使用したデプロイ設定への移行

## 変更内容
- Render Web UIの設定をrender.yamlファイルに移行
- 既存データベースを使用するよう環境変数を設定
- buildCommandとstartCommandを明示的に定義

## 変更理由
- Infrastructure as Codeによる設定管理の実現
- デプロイ設定の再現性向上
- 設定変更の履歴管理

## 技術的な変更点
- DATABASE_URLをsync: falseに設定（既存DB使用）
- bundlerバージョンを明示的に指定
- 必要な環境変数を全て定義

## 確認事項
- 既存データベースのInternal Database URLをWeb UIで設定済み
- RAILS_MASTER_KEYの設定確認済み