### PR TITLE
Add font detail

### DIFF
--- a/app/controllers/fonts_controller.rb
+++ b/app/controllers/fonts_controller.rb
@@ -1,0 +1,9 @@
+class FontsController < ApplicationController
+  def index
+    @fonts = Font.all  # 全フォントを取得
+  end
+
+  def show
+    @font = Font.find(params[:id])  # 特定のフォントを取得
+  end
+end

--- a/app/helpers/fonts_helper.rb
+++ b/app/helpers/fonts_helper.rb
@@ -1,0 +1,2 @@
+module FontsHelper
+end

--- a/app/views/fonts/index.html.erb
+++ b/app/views/fonts/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="text-lg font-bold text-4xl">Fonts#index</h1>
+  <p>Find me in app/views/fonts/index.html.erb</p>
+</div>

--- a/app/views/fonts/show.html.erb
+++ b/app/views/fonts/show.html.erb
@@ -1,0 +1,40 @@
+<main class="container mx-auto mt-28 px-5">
+  <div class="max-w-4xl mx-auto">
+    <!-- フォント情報 -->
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold mb-4"><%= @font.name %></h1>
+      <div class="flex gap-4 mb-4">
+        <span class="bg-blue-100 px-3 py-1 rounded">スタイル: <%= @font.style %></span>
+        <span class="bg-green-100 px-3 py-1 rounded">ジャンル: <%= @font.genre %></span>
+      </div>
+    </div>
+
+    <!-- プレビューエリア -->
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold mb-4">プレビュー</h2>
+      <div class="mb-4">
+        <input id="preview-text" type="text" value="サンプルテキスト"
+               placeholder="プレビューしたい文章を入力してください"
+               class="border rounded p-2 w-full" />
+      </div>
+      <div class="mb-4">
+        <label for="font-size" class="mr-2">文字サイズ</label>
+        <input type="range" id="font-size" min="10" max="72" value="24" />
+        <span id="font-size-display">24px</span>
+      </div>
+
+      <link href="<%= @font.font_url %>" rel="stylesheet">
+      <div class="border rounded p-6 bg-gray-50">
+        <p id="font-preview" style="font-family: '<%= @font.name %>', sans-serif; font-size: 24px;">
+          サンプルテキスト
+        </p>
+      </div>
+    </div>
+
+    <!-- 戻るボタン -->
+    <div class="text-center">
+      <%= link_to "フォント一覧に戻る", root_path,
+                  class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+    </div>
+  </div>
+</main>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -32,8 +32,10 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 px-6" id="font-preview-area">
     <% @fonts.each do |font| %>
       <link href="<%= font.font_url %>" rel="stylesheet">
-      <div class="border rounded p-4 shadow" data-style="<%= font.style %>" data-genre="<%= font.genre %>">
-        <h3 class="text-lg font-semibold mb-2"><%= font.name %></h3>
+      <div class="border rounded p-4 shadow hover:shadow-lg transition-shadow" data-style="<%= font.style %>" data-genre="<%= font.genre %>">
+        <h3 class="text-lg font-semibold mb-2">
+          <%= link_to font.name, font_path(font), class: "text-blue-600 hover:text-blue-800 hover:underline" %>
+        </h3>
         <p class="preview-text" style="font-family: '<%= font.name %>', sans-serif; font-size: 24px;">
           こんにちは
         </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   get 'home/index'
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
   root "home#index"
+
+  resources :fonts, only: [:index, :show]
 end

--- a/test/controllers/fonts_controller_test.rb
+++ b/test/controllers/fonts_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class FontsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get fonts_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get fonts_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 実装内容
- フォント詳細ページのルーティング追加
- FontsControllerにshowアクションを実装
- 詳細ページのビューを作成（フォント情報とプレビュー表示）
- ホームページからフォント名をクリックして詳細ページに遷移する機能

## 確認方法
1. ホームページ（http://localhost:3000）にアクセス
2. 任意のフォント名をクリック
3. 詳細ページに遷移し、フォント情報が表示されることを確認
4. 戻るリンクで一覧に戻れることを確認

## 画面仕様
- フォント名、スタイル、ジャンルの表示
- フォントを使用したプレビューテキストの表示
- 一覧ページへの戻るリンク