### PR TITLE
フォント詳細ページにJavaScript機能を追加

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "font_preview"
+import "font_detail"
 
 console.log("Application JavaScript loaded with importmap!");

--- a/app/javascript/font_detail.js
+++ b/app/javascript/font_detail.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const previewText = document.getElementById('preview-text');
+    const fontSizeSlider = document.getElementById('font-size');
+    const fontSizeDisplay = document.getElementById('font-size-display');
+    const fontPreview = document.getElementById('font-preview');
+
+    // プレビューテキストの更新
+    if (previewText && fontPreview) {
+      previewText.addEventListener('input', function() {
+        const text = this.value || 'サンプルテキスト';
+        fontPreview.textContent = text;
+      });
+    }
+
+    // フォントサイズの更新
+    if (fontSizeSlider && fontSizeDisplay && fontPreview) {
+      fontSizeSlider.addEventListener('input', function() {
+        const size = this.value;
+        fontSizeDisplay.textContent = size + 'px';
+        fontPreview.style.fontSize = size + 'px';
+      });
+    }
+});

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,2 +1,3 @@
 pin "application", preload: true
 pin "font_preview", to: "font_preview.js"
+pin "font_detail", to: "font_detail.js"


### PR DESCRIPTION
## 実装内容
- フォント詳細ページでのプレビューテキスト編集機能
- フォントサイズをスライダーで調整する機能
- リアルタイムでプレビューが更新される機能

## 技術的な変更点
- `app/javascript/font_detail.js`を新規作成
- importmapでのJavaScript管理設定を追加
- 既存の`font_preview.js`機能との共存

## 動作確認方法
1. フォント詳細ページにアクセス
2. プレビューテキストを入力して即座に反映されることを確認
3. フォントサイズスライダーで文字サイズが変更されることを確認