### PR TITLE
フォント情報要素の追加

### DIFF
--- a/app/views/fonts/show.html.erb
+++ b/app/views/fonts/show.html.erb
@@ -62,6 +62,164 @@
       </div>
     </div>
 
+    <!-- ライセンス情報セクション -->
+    <div class="bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 mb-8 animate-fadeIn">
+      <h2 class="text-2xl font-bold text-gray-800 mb-6 flex items-center">
+        <i class="fas fa-certificate text-green-500 mr-3"></i>
+        ライセンス情報
+      </h2>
+
+      <div class="grid md:grid-cols-2 gap-6">
+        <!-- 商用利用可否 -->
+        <div class="bg-gradient-to-br from-gray-50 to-white border-2 border-gray-200 rounded-xl p-6 hover:shadow-md transition-all duration-300">
+          <div class="flex items-center mb-3">
+            <i class="fas fa-store text-blue-500 mr-3 text-xl"></i>
+            <h3 class="text-lg font-bold text-gray-800">商用利用</h3>
+          </div>
+          <div class="flex items-center">
+            <% if @font.commercial_use %>
+              <div class="bg-gradient-to-r from-green-500 to-green-600 text-white px-4 py-2 rounded-full text-sm font-bold shadow-md flex items-center">
+                <i class="fas fa-check-circle mr-2"></i>
+                利用可能
+              </div>
+            <% else %>
+              <div class="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white px-4 py-2 rounded-full text-sm font-bold shadow-md flex items-center">
+                <i class="fas fa-exclamation-triangle mr-2"></i>
+                要確認
+              </div>
+            <% end %>
+          </div>
+          <p class="text-gray-600 text-sm mt-3">
+            <% if @font.commercial_use %>
+              このフォントは商用プロジェクトでも安心してご利用いただけます。
+            <% else %>
+              商用利用については、ライセンス詳細をご確認ください。
+            <% end %>
+          </p>
+        </div>
+
+        <!-- ライセンス種類 -->
+        <div class="bg-gradient-to-br from-gray-50 to-white border-2 border-gray-200 rounded-xl p-6 hover:shadow-md transition-all duration-300">
+          <div class="flex items-center mb-3">
+            <i class="fas fa-file-contract text-purple-500 mr-3 text-xl"></i>
+            <h3 class="text-lg font-bold text-gray-800">ライセンス</h3>
+          </div>
+          <div class="mb-3">
+            <span class="bg-gradient-to-r from-purple-500 to-purple-600 text-white px-4 py-2 rounded-full text-sm font-bold shadow-md">
+              <%= @font.license_type %>
+            </span>
+          </div>
+          <p class="text-gray-600 text-sm">
+            詳細な利用規約については、下記のライセンス詳細をご確認ください。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- フォント入手方法セクション -->
+    <div class="bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 p-8 mb-8 animate-fadeIn">
+      <h2 class="text-2xl font-bold text-gray-800 mb-6 flex items-center">
+        <i class="fas fa-download text-indigo-500 mr-3"></i>
+        フォントの入手方法
+      </h2>
+
+      <div class="space-y-6">
+        <!-- CDNで使用 -->
+        <div class="bg-gradient-to-br from-blue-50 to-blue-100 border-2 border-blue-200 rounded-xl p-6 hover:shadow-md transition-all duration-300">
+          <div class="flex items-center mb-4">
+            <i class="fas fa-link text-blue-500 mr-3 text-xl"></i>
+            <h3 class="text-lg font-bold text-gray-800">CDNで使用（推奨）</h3>
+            <span class="bg-blue-500 text-white px-3 py-1 rounded-full text-xs font-bold ml-3">簡単</span>
+          </div>
+          
+          <p class="text-gray-700 mb-4 text-sm">
+            HTMLの&lt;head&gt;タグ内に以下のコードを追加するだけで使用できます
+          </p>
+          
+          <div class="bg-white border-2 border-blue-300 rounded-lg p-4 font-mono text-sm overflow-x-auto">
+            <div class="flex justify-between items-start">
+              <code class="text-gray-800 break-all flex-1 mr-4">
+                &lt;link href="<%= @font.font_url %>" rel="stylesheet"&gt;
+              </code>
+              <button onclick="copyToClipboard('<%= @font.font_url %>')" 
+                      class="bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded text-xs font-bold transition-colors duration-300 flex items-center whitespace-nowrap">
+                <i class="fas fa-copy mr-1"></i>
+                コピー
+              </button>
+            </div>
+          </div>
+          
+          <div class="mt-4 p-3 bg-blue-100 rounded-lg">
+            <p class="text-blue-800 text-sm font-medium">
+              <i class="fas fa-lightbulb mr-2"></i>
+              CSS での使用例: <code class="bg-white px-2 py-1 rounded text-blue-900">font-family: '<%= @font.name %>', sans-serif;</code>
+            </p>
+          </div>
+        </div>
+
+        <!-- ダウンロードして使用 -->
+        <div class="bg-gradient-to-br from-green-50 to-green-100 border-2 border-green-200 rounded-xl p-6 hover:shadow-md transition-all duration-300">
+          <div class="flex items-center mb-4">
+            <i class="fas fa-download text-green-500 mr-3 text-xl"></i>
+            <h3 class="text-lg font-bold text-gray-800">ダウンロードして使用</h3>
+            <span class="bg-green-500 text-white px-3 py-1 rounded-full text-xs font-bold ml-3">オフライン対応</span>
+          </div>
+          
+          <p class="text-gray-700 mb-4 text-sm">
+            フォントファイルをローカルにダウンロードして使用する方法です
+          </p>
+          
+          <div class="flex flex-wrap gap-3">
+            <%= link_to @font.download_url, 
+                        target: "_blank", 
+                        rel: "noopener noreferrer",
+                        class: "bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white font-bold py-3 px-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 flex items-center" do %>
+              <i class="fas fa-external-link-alt mr-2"></i>
+              Google Fontsでダウンロード
+            <% end %>
+            
+            <%= link_to @font.license_url, 
+                        target: "_blank", 
+                        rel: "noopener noreferrer",
+                        class: "bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 text-white font-bold py-3 px-6 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105 flex items-center" do %>
+              <i class="fas fa-file-contract mr-2"></i>
+              ライセンス詳細を確認
+            <% end %>
+          </div>
+          
+          <div class="mt-4 p-3 bg-green-100 rounded-lg">
+            <p class="text-green-800 text-sm font-medium">
+              <i class="fas fa-info-circle mr-2"></i>
+              ダウンロード後は、CSSで <code class="bg-white px-2 py-1 rounded text-green-900">@font-face</code> を使用して読み込んでください
+            </p>
+          </div>
+        </div>
+
+        <!-- 使用上の注意 -->
+        <div class="bg-gradient-to-br from-yellow-50 to-yellow-100 border-2 border-yellow-200 rounded-xl p-6 hover:shadow-md transition-all duration-300">
+          <div class="flex items-center mb-4">
+            <i class="fas fa-exclamation-triangle text-yellow-500 mr-3 text-xl"></i>
+            <h3 class="text-lg font-bold text-gray-800">使用上の注意</h3>
+          </div>
+          
+          <div class="space-y-2 text-sm text-gray-700">
+            <p class="flex items-start">
+              <i class="fas fa-check text-yellow-500 mr-2 mt-1 flex-shrink-0"></i>
+              <span>使用前に必ずライセンス詳細をご確認ください</span>
+            </p>
+            <p class="flex items-start">
+              <i class="fas fa-check text-yellow-500 mr-2 mt-1 flex-shrink-0"></i>
+              <span>商用プロジェクトの場合は、ライセンス条項を十分にご理解ください</span>
+            </p>
+            <p class="flex items-start">
+              <i class="fas fa-check text-yellow-500 mr-2 mt-1 flex-shrink-0"></i>
+              <span>フォントの再配布は禁止されている場合があります</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- ナビゲーションエリア -->
     <div class="flex justify-center animate-fadeIn">
       <%= link_to root_path,
@@ -108,6 +266,91 @@ document.addEventListener('DOMContentLoaded', function() {
     fontSizeDisplay.textContent = urlFontSize + 'px';
     fontPreview.style.fontSize = urlFontSize + 'px';
   }
+
+// コピー機能
+function copyToClipboard(text) {
+  const linkTag = `<link href="${text}" rel="stylesheet">`;
+
+  navigator.clipboard.writeText(linkTag).then(function() {
+    showToast('CDNリンクをコピーしました！', 'success');
+  }).catch(function() {
+    // フォールバック（古いブラウザ対応）
+    const textArea = document.createElement('textarea');
+    textArea.value = linkTag;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+    showToast('CDNリンクをコピーしました！', 'success');
+  });
+}
+
+// トースト通知表示
+function showToast(message, type = 'info') {
+  // 既存のトーストがあれば削除
+  const existingToast = document.querySelector('.custom-toast');
+  if (existingToast) {
+    existingToast.remove();
+  }
+
+  const toast = document.createElement('div');
+  toast.className = 'custom-toast fixed top-20 right-5 z-50 px-6 py-4 rounded-xl shadow-2xl transform translate-x-full transition-all duration-300';
+
+  // タイプに応じて色を変更
+  let colorClasses = '';
+  let icon = '';
+
+  switch(type) {
+    case 'success':
+      colorClasses = 'bg-gradient-to-r from-green-500 to-green-600 text-white';
+      icon = '<i class="fas fa-check-circle mr-2"></i>';
+      break;
+    case 'error':
+      colorClasses = 'bg-gradient-to-r from-red-500 to-red-600 text-white';
+      icon = '<i class="fas fa-exclamation-circle mr-2"></i>';
+      break;
+    case 'warning':
+      colorClasses = 'bg-gradient-to-r from-yellow-500 to-yellow-600 text-white';
+      icon = '<i class="fas fa-exclamation-triangle mr-2"></i>';
+      break;
+    default:
+      colorClasses = 'bg-gradient-to-r from-blue-500 to-blue-600 text-white';
+      icon = '<i class="fas fa-info-circle mr-2"></i>';
+  }
+
+  toast.className += ' ' + colorClasses;
+  toast.innerHTML = `
+    <div class="flex items-center font-bold">
+      ${icon}
+      <span>${message}</span>
+    </div>
+  `;
+
+  document.body.appendChild(toast);
+
+  // アニメーション：スライドイン
+  setTimeout(() => {
+    toast.style.transform = 'translateX(0)';
+  }, 100);
+
+  // 3秒後に自動削除
+  setTimeout(() => {
+    toast.style.transform = 'translateX(100%)';
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
+  }, 3000);
+
+  // クリックで削除
+  toast.addEventListener('click', function() {
+    toast.style.transform = 'translateX(100%)';
+    setTimeout(() => {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
 
 });
 </script>

--- a/db/migrate/20250731061441_add_license_info_to_fonts.rb
+++ b/db/migrate/20250731061441_add_license_info_to_fonts.rb
@@ -1,0 +1,7 @@
+class AddLicenseInfoToFonts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :fonts, :commercial_use, :boolean, default: true, null: false
+    add_column :fonts, :license_type, :string, null: false, default: 'SIL Open Font License'
+    add_column :fonts, :license_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_24_121734) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_31_061441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_24_121734) do
     t.string "download_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "commercial_use", default: true, null: false
+    t.string "license_type", default: "SIL Open Font License", null: false
+    t.string "license_url"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,10 @@ begin
     style: "明朝体",
     genre: "上品",
     font_url: "https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&display=swap",
-    download_url: "https://fonts.google.com/noto/specimen/Noto+Serif+JP"
+    download_url: "https://fonts.google.com/noto/specimen/Noto+Serif+JP",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -17,7 +20,10 @@ begin
     style: "明朝体",
     genre: "上品",
     font_url: "https://fonts.googleapis.com/css2?family=Sawarabi+Mincho&display=swap",
-    download_url: "https://fonts.google.com/specimen/Sawarabi+Mincho"
+    download_url: "https://fonts.google.com/specimen/Sawarabi+Mincho",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -25,7 +31,10 @@ begin
     style: "ゴシック体",
     genre: "ビジネス",
     font_url: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap",
-    download_url: "https://fonts.google.com/specimen/Noto+Sans+JP"
+    download_url: "https://fonts.google.com/specimen/Noto+Sans+JP",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -33,7 +42,10 @@ begin
     style: "ゴシック体",
     genre: "ビジネス",
     font_url: "https://fonts.googleapis.com/css2?family=M+PLUS+1p&display=swap",
-    download_url: "https://fonts.google.com/specimen/M+PLUS+1p"
+    download_url: "https://fonts.google.com/specimen/M+PLUS+1p",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -41,7 +53,10 @@ begin
     style: "ゴシック体",
     genre: "インパクト",
     font_url: "https://fonts.googleapis.com/css2?family=Dela+Gothic+One&display=swap",
-    download_url: "https://fonts.google.com/specimen/Dela+Gothic+One"
+    download_url: "https://fonts.google.com/specimen/Dela+Gothic+One",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -49,7 +64,10 @@ begin
     style: "丸ゴシック体",
     genre: "かわいい",
     font_url: "https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&display=swap",
-    download_url: "https://fonts.google.com/specimen/M+PLUS+Rounded+1c"
+    download_url: "https://fonts.google.com/specimen/M+PLUS+Rounded+1c",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -57,7 +75,10 @@ begin
     style: "丸ゴシック体",
     genre: "かわいい",
     font_url: "https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic&display=swap",
-    download_url: "https://fonts.google.com/specimen/Zen+Maru+Gothic"
+    download_url: "https://fonts.google.com/specimen/Zen+Maru+Gothic",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -65,7 +86,10 @@ begin
     style: "筆書体",
     genre: "かっこいい",
     font_url: "https://fonts.googleapis.com/css2?family=Yuji+Boku&display=swap",
-    download_url: "https://fonts.google.com/specimen/Yuji+Boku"
+    download_url: "https://fonts.google.com/specimen/Yuji+Boku",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -73,7 +97,10 @@ begin
     style: "筆書体",
     genre: "かっこいい",
     font_url: "https://fonts.googleapis.com/css2?family=Yuji+Mai&display=swap",
-    download_url: "https://fonts.google.com/specimen/Yuji+Mai"
+    download_url: "https://fonts.google.com/specimen/Yuji+Mai",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -81,7 +108,10 @@ begin
     style: "筆書体",
     genre: "かっこいい",
     font_url: "https://fonts.googleapis.com/css2?family=Yuji+Syuku&display=swap",
-    download_url: "https://fonts.google.com/specimen/Yuji+Syuku"
+    download_url: "https://fonts.google.com/specimen/Yuji+Syuku",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -89,7 +119,10 @@ begin
     style: "デザインフォント",
     genre: "かわいい",
     font_url: "https://fonts.googleapis.com/css2?family=Kaisei+Decol&display=swap",
-    download_url: "https://fonts.google.com/specimen/Kaisei+Decol"
+    download_url: "https://fonts.google.com/specimen/Kaisei+Decol",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   },
 
   {
@@ -97,7 +130,10 @@ begin
     style: "デザインフォント",
     genre: "かわいい",
     font_url: "https://fonts.googleapis.com/css2?family=Mochiy+Pop+One&display=swap",
-    download_url: "https://fonts.google.com/specimen/Mochiy+Pop+One"
+    download_url: "https://fonts.google.com/specimen/Mochiy+Pop+One",
+    commercial_use: true,
+    license_type: "SIL Open Font License",
+    license_url: "https://openfontlicense.org/"
   }
 
 ]


### PR DESCRIPTION
## 変更内容

### データベース
- `fonts`テーブルに以下のカラムを追加：
  - `commercial_use`: 商用利用可否（boolean）
  - `license_type`: ライセンス種類（string）
  - `license_url`: ライセンス詳細URL（string）

### UI/UX改善
- ライセンス情報セクションの追加
  - 商用利用可否の視覚的表示
  - ライセンス種類の明示
- フォント入手方法セクションの追加
  - CDN使用方法（推奨）
  - ダウンロード方法
  - 使用上の注意事項
 
## テスト確認項目
- ライセンス情報が正しく表示される
- 商用利用可否のアイコンが適切に表示される
- CDNリンクのコピー機能が動作する
- トースト通知が適切に表示・消去される
- ダウンロードリンクが正しく機能する
